### PR TITLE
feat: strip well-known tracking query params from feed URLs

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,6 +1,7 @@
 import { Client as NotionClient, collectPaginatedAPI } from '@notionhq/client';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { FeedItem } from './models';
+import { sanitizeTrackingParams } from './sanitize-url';
 
 type NotionProperty<T extends string> = PageObjectResponse['properties'][string] & { type: T };
 
@@ -42,7 +43,7 @@ export async function fetchNewFeedItems(notion: NotionClient, notionDatabaseId: 
     assertPropertyType(properties.url, 'url');
     assertPropertyType(properties.feed2social_completed, 'multi_select');
 
-    const url = properties.url.url ?? '';
+    const url = sanitizeTrackingParams(properties.url.url ?? '');
     if (url === '') {
       console.log(`skipped: ${page.id} has no url`);
       continue;

--- a/src/sanitize-url.ts
+++ b/src/sanitize-url.ts
@@ -1,0 +1,85 @@
+// Well-known tracking query parameters. Conservative list — start minimal.
+// 拡張する場合はサイト別の誤検出に注意（特に `ref` / `source` は除外している）。
+const TRACKING_PARAMS: ReadonlySet<string> = new Set([
+  // Google Analytics / UTM
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+  // Google Ads
+  'gclid',
+  // Facebook
+  'fbclid',
+]);
+
+export function sanitizeTrackingParams(input: string): string {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return input;
+  }
+
+  let mutated = false;
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (TRACKING_PARAMS.has(key)) {
+      url.searchParams.delete(key);
+      mutated = true;
+    }
+  }
+  if (!mutated) {
+    return input;
+  }
+  return url.toString();
+}
+
+if (import.meta.vitest) {
+  const { describe, test, expect } = import.meta.vitest;
+
+  describe('sanitizeTrackingParams', () => {
+    test('returns input as-is when there are no query params', () => {
+      expect(sanitizeTrackingParams('https://example.com/path')).toBe('https://example.com/path');
+    });
+
+    test('returns input as-is when no tracking params are present', () => {
+      expect(sanitizeTrackingParams('https://example.com/?q=foo&page=2')).toBe('https://example.com/?q=foo&page=2');
+    });
+
+    test('removes utm_* params', () => {
+      const input = 'https://example.com/article?utm_source=newsletter&utm_medium=email&utm_campaign=spring';
+      expect(sanitizeTrackingParams(input)).toBe('https://example.com/article');
+    });
+
+    test('removes gclid and fbclid', () => {
+      expect(sanitizeTrackingParams('https://example.com/?gclid=abc')).toBe('https://example.com/');
+      expect(sanitizeTrackingParams('https://example.com/?fbclid=xyz')).toBe('https://example.com/');
+    });
+
+    test('keeps legitimate params while stripping tracking params', () => {
+      const input = 'https://example.com/search?q=feed2social&utm_source=twitter&page=2';
+      const result = sanitizeTrackingParams(input);
+      const url = new URL(result);
+      expect(url.searchParams.get('q')).toBe('feed2social');
+      expect(url.searchParams.get('page')).toBe('2');
+      expect(url.searchParams.has('utm_source')).toBe(false);
+    });
+
+    test('preserves fragment', () => {
+      expect(sanitizeTrackingParams('https://example.com/doc?utm_source=foo#section-2')).toBe('https://example.com/doc#section-2');
+    });
+
+    test('preserves path, scheme, host, and port', () => {
+      expect(sanitizeTrackingParams('http://example.com:8080/a/b?utm_id=x')).toBe('http://example.com:8080/a/b');
+    });
+
+    test('returns input as-is when URL is not parseable', () => {
+      expect(sanitizeTrackingParams('not a url')).toBe('not a url');
+    });
+
+    test('returns empty string as-is', () => {
+      expect(sanitizeTrackingParams('')).toBe('');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Notion ブックマーク DB から取得した URL に utm_* / gclid / fbclid のような well-known なトラッキングパラメータが付いていたら、SNS 投稿前に剥がす
- 適用箇所は `repository.ts` の Notion 入力境界に閉じる。`FeedItem.feedUrl` が以降クリーンな状態で流れるため、`fetchPageTitle(feedUrl)` と `PostData.url` の両方が自動的にクリーンになる
- Notion DB 側の URL は書き換えない（元データ保持）

## Implementation
- 新規 `src/sanitize-url.ts`: 純粋関数 `sanitizeTrackingParams(input: string) => string`。in-source vitest 9 ケース
- 対象パラメータは保守的に 8 個: `utm_source` / `utm_medium` / `utm_campaign` / `utm_term` / `utm_content` / `utm_id` / `gclid` / `fbclid`。誤検出リスクのある `ref` / `source` 等は除外
- URL parse 失敗時は **fail-open** で元文字列を返す（Notion 入力不正で投稿全停止を避ける）
- tracking なしの URL は参照同一性を保ち元文字列を返す（`URL.toString()` 経由の些細な正規化を避ける）
- `repository.ts` の差分は 1 行（`properties.url.url ?? ''` を `sanitizeTrackingParams(...)` でラップ）+ import 1 行

## Test plan
- [x] `pnpm run lint` (prettier --check) ローカル pass
- [x] `pnpm run test:ci` (vitest) ローカル 24/24 pass
- [ ] main merge 後、`deploy-production.yml` で wrangler 自動デプロイ → 次回 5 分 cron で utm_* 付き URL が剥がれた状態で SNS 投稿されることを確認
