### PR TITLE
fix: migrate to Notion SDK v5 dataSources.query

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,5 +1,4 @@
-import { Client as NotionClient, collectPaginatedAPI } from '@notionhq/client';
-import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { Client as NotionClient, collectPaginatedAPI, PageObjectResponse } from '@notionhq/client';
 import { FeedItem } from './models';
 import { sanitizeTrackingParams } from './sanitize-url';
 
@@ -7,8 +6,11 @@ type NotionProperty<T extends string> = PageObjectResponse['properties'][string]
 
 export async function fetchNewFeedItems(notion: NotionClient, notionDatabaseId: string): Promise<FeedItem[]> {
   const items: FeedItem[] = [];
-  const pages = await collectPaginatedAPI(notion.databases.query, {
-    database_id: notionDatabaseId,
+  // Notion API v2025-09-03 で multi-source database 対応のため、
+  // クエリは `databases.query` から `dataSources.query` に移動した。
+  // single-source database では既存の database_id をそのまま data_source_id として使用できる。
+  const pages = await collectPaginatedAPI(notion.dataSources.query, {
+    data_source_id: notionDatabaseId,
     sorts: [{ timestamp: 'created_time', direction: 'descending' }],
     filter: {
       and: [


### PR DESCRIPTION
## Background

PR #91 で `@notionhq/client` を v3 → v5 にメジャー bump した結果、Notion API v2025-09-03 の **multi-source database 対応**で `databases.query` が `dataSources.query` に移動しており、本番の 5 分 cron が `TypeError: listFn is not a function` で連続失敗していた（Sentry, release `53eabd0`、`failed to fetch new feed items: TypeError: ...`）。

`collectPaginatedAPI(notion.databases.query, {...})` の第 1 引数 `listFn` が v5 では `undefined`（`databases` 名前空間に `query` メソッドが存在しなくなった）。

## Fix

`src/repository.ts`:
- `notion.databases.query` → `notion.dataSources.query`
- パラメータ `database_id` → `data_source_id`
- `PageObjectResponse` の import を deep path (`@notionhq/client/build/src/api-endpoints`) から top-level export (`@notionhq/client`) に整理

`sorts` / `filter` 構文と `pages.update` 経路は v5 でも変更なし。

## 環境変数

`NOTION_DATABASE_ID` (= `bce0d0a9147e468ca227788ca1797d28`) はそのまま使用。Notion API v2025-09-03 仕様では **single-source database では既存の database_id をそのまま data_source_id として使える** 互換性が提供されている（multi-source 化していなければ追加の lookup 不要）。`#laco_feed` DB は single source 想定。

## Test plan

- [x] `pnpm run lint` (prettier --check) green
- [x] `pnpm run test:ci` (vitest) 24/24 pass
- [x] `pnpm exec tsc --noEmit` で `repository.ts` の型エラーゼロ（tsconfig.json の `moduleResolution: node` deprecation 警告は本タスク外）
- [ ] main merge 後、`deploy-production.yml` で wrangler 自動デプロイ → 次回 5 分 cron で Sentry の `TypeError: listFn is not a function` が停止 + 投稿成功（または別エラー検出）
