### PR TITLE
fix: resolve data_source_id from database before query

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,4 +1,4 @@
-import { Client as NotionClient, collectPaginatedAPI, PageObjectResponse } from '@notionhq/client';
+import { Client as NotionClient, collectPaginatedAPI, isFullDatabase, PageObjectResponse } from '@notionhq/client';
 import { FeedItem } from './models';
 import { sanitizeTrackingParams } from './sanitize-url';
 
@@ -7,10 +7,20 @@ type NotionProperty<T extends string> = PageObjectResponse['properties'][string]
 export async function fetchNewFeedItems(notion: NotionClient, notionDatabaseId: string): Promise<FeedItem[]> {
   const items: FeedItem[] = [];
   // Notion API v2025-09-03 で multi-source database 対応のため、
-  // クエリは `databases.query` から `dataSources.query` に移動した。
-  // single-source database では既存の database_id をそのまま data_source_id として使用できる。
+  // クエリは `databases.query` から `dataSources.query` に移動し、
+  // 引数も database_id ではなく data_source_id を取るようになった。
+  // 既存 env (`NOTION_DATABASE_ID`) は database id のままなので、
+  // ここで該当 database の data source id を解決する。
+  const database = await notion.databases.retrieve({ database_id: notionDatabaseId });
+  if (!isFullDatabase(database)) {
+    throw new Error(`Cannot resolve data sources for partial database response: ${notionDatabaseId}`);
+  }
+  const dataSourceId = database.data_sources[0]?.id;
+  if (!dataSourceId) {
+    throw new Error(`No data sources found in database: ${notionDatabaseId}`);
+  }
   const pages = await collectPaginatedAPI(notion.dataSources.query, {
-    data_source_id: notionDatabaseId,
+    data_source_id: dataSourceId,
     sorts: [{ timestamp: 'created_time', direction: 'descending' }],
     filter: {
       and: [


### PR DESCRIPTION
## Background

PR #92 で `databases.query` → `dataSources.query` に切り替えたが、Notion v2025-09-03 では **`database_id` ≠ `data_source_id`** で、`NOTION_DATABASE_ID` をそのまま `data_source_id` として渡しても `APIResponseError: Could not find database with ID: ...` で失敗する（Sentry, release `2058e72`、PR #92 deploy 後の cron で観測）。

## Fix

`src/repository.ts` の `fetchNewFeedItems` 先頭で、`notion.databases.retrieve({ database_id })` を呼び、`data_sources[0].id` を取り出してから `dataSources.query` に渡す。`isFullDatabase` helper で `PartialDatabaseObjectResponse` の type narrowing。

- single-source database 前提（feed2social の `#laco_feed` DB は単一 source）。multi-source DB の場合は先頭の data source を使用。
- env (`NOTION_DATABASE_ID`) と wrangler.toml `[vars]` は変更不要。
- query あたり Notion API call が 1 → 2 に増える（retrieve + query）が、5 分 cron で実用上の差は無視できる。

## Test plan

- [x] `pnpm run lint` (prettier --check) green
- [x] `pnpm run test:ci` (vitest) 24/24 pass
- [ ] main merge 後、`deploy-production.yml` で wrangler 自動デプロイ → 次回 5 分 cron で Sentry の `APIResponseError: Could not find database with ID` が停止 + 投稿成功（あるいは別エラー検出）
