### PR TITLE
fix: pass NOTION_DATA_SOURCE_ID directly to dataSources.query

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,13 +4,12 @@ import { sanitizeTrackingParams } from './sanitize-url';
 
 type NotionProperty<T extends string> = PageObjectResponse['properties'][string] & { type: T };
 
-export async function fetchNewFeedItems(notion: NotionClient, notionDatabaseId: string): Promise<FeedItem[]> {
+export async function fetchNewFeedItems(notion: NotionClient, dataSourceId: string): Promise<FeedItem[]> {
   const items: FeedItem[] = [];
-  // Notion API v2025-09-03 で multi-source database 対応のため、
-  // クエリは `databases.query` から `dataSources.query` に移動した。
-  // single-source database では既存の database_id をそのまま data_source_id として使用できる。
+  // Notion API v2025-09-03 で query は data source 単位に変更された。
+  // 呼び出し側 (`worker.ts`) が `NOTION_DATA_SOURCE_ID` を直接渡す前提。
   const pages = await collectPaginatedAPI(notion.dataSources.query, {
-    data_source_id: notionDatabaseId,
+    data_source_id: dataSourceId,
     sorts: [{ timestamp: 'created_time', direction: 'descending' }],
     filter: {
       and: [

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,7 +12,7 @@ export type Env = {
   SENTRY_DSN: string;
   SENTRY_RELEASE: string;
   NOTION_TOKEN: string;
-  NOTION_DATABASE_ID: string;
+  NOTION_DATA_SOURCE_ID: string;
   MISSKEY_TOKEN: string;
   BSKY_ID: string;
   BSKY_PASSWORD: string;
@@ -44,7 +44,7 @@ async function execute(env: Env, sentry: Sentry, dryRun = false) {
 
   let incomingFeedItems: FeedItem[] = [];
   try {
-    incomingFeedItems = await fetchNewFeedItems(notion, env.NOTION_DATABASE_ID);
+    incomingFeedItems = await fetchNewFeedItems(notion, env.NOTION_DATA_SOURCE_ID);
     console.log(`new items: ${incomingFeedItems.length}`);
   } catch (e) {
     throw new Error(`failed to fetch new feed items: ${e}`, { cause: e });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,6 +15,6 @@ crons = ["*/5 * * * *"]
 
 [vars]
 BSKY_ID = "lacolaco.bsky.social"
-NOTION_DATABASE_ID = "bce0d0a9147e468ca227788ca1797d28"
+NOTION_DATA_SOURCE_ID = "800e0eb6-03c4-4fd0-81a3-c4f11fa107eb"
 SENTRY_DSN = "https://2037e01514d53cf9de52433a5d5d5626@o4505734726549504.ingest.sentry.io/4505734743523328"
 SENTRY_RELEASE = "${SENTRY_RELEASE}"


### PR DESCRIPTION
## Background

PR #92 で `databases.query` → `dataSources.query` に切り替えた後、`NOTION_DATABASE_ID` をそのまま `data_source_id` として渡しても Notion から `APIResponseError: Could not find database with ID: ...` を返される（Notion API v2025-09-03 では database id と data source id が別物）。

## Fix

env を **`NOTION_DATA_SOURCE_ID`** に切り替えて `dataSources.query` に直接渡す。

- `wrangler.toml [vars]`: `NOTION_DATABASE_ID = "bce0d0a9..."` → `NOTION_DATA_SOURCE_ID = "800e0eb6-03c4-4fd0-81a3-c4f11fa107eb"`（`#laco_feed` DB の data source id）。
- `src/worker.ts`: `Env.NOTION_DATABASE_ID` を `NOTION_DATA_SOURCE_ID` に rename、`fetchNewFeedItems` 呼び出しを env から直接渡す。
- `src/repository.ts`: 引数名を `notionDatabaseId` から `dataSourceId` に変更、`databases.retrieve` を介した resolve は不採用。

retrieve を経由する案 (closed PR #93) と比べて Notion API call が 1 回減り、env 名が実体と一致してドリフトが起きにくくなる。

## Test plan

- [x] `pnpm run lint` (prettier --check) green
- [x] `pnpm run test:ci` (vitest) 24/24 pass
- [ ] main merge 後、`deploy-production.yml` で wrangler 自動デプロイ → 次回 5 分 cron で Sentry の `APIResponseError: Could not find database with ID` が停止 + 投稿成功
