### PR TITLE
fix: rescue stale bookmarks past week boundary, isolate per-item failures

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -27,14 +27,14 @@ export function buildFeedItemFilter(now: Date) {
   };
 }
 
-export async function fetchNewFeedItems(notion: NotionClient, dataSourceId: string): Promise<FeedItem[]> {
+export async function fetchNewFeedItems(notion: NotionClient, dataSourceId: string, now: Date = new Date()): Promise<FeedItem[]> {
   const items: FeedItem[] = [];
   // Notion API v2025-09-03 で query は data source 単位に変更された。
   // 呼び出し側 (`worker.ts`) が `NOTION_DATA_SOURCE_ID` を直接渡す前提。
   const pages = await collectPaginatedAPI(notion.dataSources.query, {
     data_source_id: dataSourceId,
     sorts: [{ timestamp: 'created_time', direction: 'descending' }],
-    filter: buildFeedItemFilter(new Date()),
+    filter: buildFeedItemFilter(now),
   });
   for (const page of pages) {
     if (page.object !== 'page' || !('properties' in page)) {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,6 +4,29 @@ import { sanitizeTrackingParams } from './sanitize-url';
 
 type NotionProperty<T extends string> = PageObjectResponse['properties'][string] & { type: T };
 
+// `this_week` はワークスペースのタイムゾーン基準で「現在のカレンダー週」だけを含むため、
+// 週の切り替わりや投稿し損ねたブックマークが永久に拾われなくなる境界バグがあった。
+// 固定ローリング窓 (現在時刻から past N 日) で取りこぼしを防ぐ。
+const FEED_ITEM_LOOKBACK_DAYS = 8;
+
+export function buildFeedItemFilter(now: Date) {
+  const since = new Date(now.getTime() - FEED_ITEM_LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  return {
+    and: [
+      { timestamp: 'created_time' as const, created_time: { on_or_after: since } },
+      { property: 'url', url: { is_not_empty: true as const } },
+      { property: 'feed2social', checkbox: { does_not_equal: true } },
+      {
+        or: [
+          { property: 'feed2social_completed', multi_select: { does_not_contain: 'misskey' } },
+          { property: 'feed2social_completed', multi_select: { does_not_contain: 'bluesky' } },
+          { property: 'feed2social_completed', multi_select: { does_not_contain: 'twitter' } },
+        ],
+      },
+    ],
+  };
+}
+
 export async function fetchNewFeedItems(notion: NotionClient, dataSourceId: string): Promise<FeedItem[]> {
   const items: FeedItem[] = [];
   // Notion API v2025-09-03 で query は data source 単位に変更された。
@@ -11,24 +34,7 @@ export async function fetchNewFeedItems(notion: NotionClient, dataSourceId: stri
   const pages = await collectPaginatedAPI(notion.dataSources.query, {
     data_source_id: dataSourceId,
     sorts: [{ timestamp: 'created_time', direction: 'descending' }],
-    filter: {
-      and: [
-        // 前週以前のものは除外
-        { timestamp: 'created_time', created_time: { this_week: {} } },
-        // URLが空のものは除外
-        { property: 'url', url: { is_not_empty: true } },
-        // feed2socialがtrueのものは除外
-        { property: 'feed2social', checkbox: { does_not_equal: true } },
-        // feed2social_completedがmisskey, bluesky, twitterのいずれかを含まないもの
-        {
-          or: [
-            { property: 'feed2social_completed', multi_select: { does_not_contain: 'misskey' } },
-            { property: 'feed2social_completed', multi_select: { does_not_contain: 'bluesky' } },
-            { property: 'feed2social_completed', multi_select: { does_not_contain: 'twitter' } },
-          ],
-        },
-      ],
-    },
+    filter: buildFeedItemFilter(new Date()),
   });
   for (const page of pages) {
     if (page.object !== 'page' || !('properties' in page)) {
@@ -72,4 +78,26 @@ function assertPropertyType<T extends string>(obj: { type: string }, type: T): a
   if (obj.type !== type) {
     throw new Error(`unexpected type: ${obj.type}`);
   }
+}
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+  describe('buildFeedItemFilter', () => {
+    it('uses an 8-day rolling window on created_time instead of this_week', () => {
+      const now = new Date('2026-06-22T03:00:00.000Z');
+      const filter = buildFeedItemFilter(now);
+      expect(filter.and[0]).toEqual({
+        timestamp: 'created_time',
+        created_time: { on_or_after: '2026-06-14T03:00:00.000Z' },
+      });
+    });
+
+    it('keeps url, feed2social, and per-network OR clauses intact', () => {
+      const filter = buildFeedItemFilter(new Date('2026-06-22T00:00:00.000Z'));
+      expect(filter.and[1]).toEqual({ property: 'url', url: { is_not_empty: true } });
+      expect(filter.and[2]).toEqual({ property: 'feed2social', checkbox: { does_not_equal: true } });
+      const orClause = filter.and[3] as { or: Array<{ multi_select: { does_not_contain: string } }> };
+      expect(orClause.or.map((c) => c.multi_select.does_not_contain)).toEqual(['misskey', 'bluesky', 'twitter']);
+    });
+  });
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,8 +52,11 @@ async function execute(env: Env, sentry: Sentry, dryRun = false) {
 
   sentry.addBreadcrumb({ level: 'log', message: 'posting feed items to social' });
 
-  try {
-    for (const feedItem of incomingFeedItems) {
+  for (const feedItem of incomingFeedItems) {
+    // 1 件の処理失敗 (Notion 5xx、status 更新失敗、createPost 後の予期せぬ例外) が
+    // バッチ全体を中止させると、同じバッチの後続アイテムが次のティックで再投稿対象になり、
+    // すでに成功したネットワークへ重複投稿される。各アイテムを独立した try/catch で隔離する。
+    try {
       sentry.addBreadcrumb({ level: 'log', message: 'posting feed item to social', data: feedItem });
       console.log(`posting: ${JSON.stringify(feedItem, null, 2)}`);
 
@@ -87,9 +90,10 @@ async function execute(env: Env, sentry: Sentry, dryRun = false) {
       } else {
         await saveFeedItemStatus(notion, feedItem);
       }
+    } catch (e) {
+      console.error(`failed to process feed item ${feedItem.notionPageId}:`, e);
+      sentry.captureException(e);
     }
-  } catch (e) {
-    throw new Error(`failed to post feed items to social: ${e}`);
   }
 
   sentry.addBreadcrumb({ level: 'log', message: 'done' });


### PR DESCRIPTION
## 症状

Notion にブックマークを追加しても SNS に投稿されない問題。Cron は `*/5 * * * *` で予定通り発火 (Cloudflare Workers Observability で 1990/2016 起動 = 98.7%、outcome=ok)、Sentry に未解決 issue ゼロ。にもかかわらず `fetchNewFeedItems` がほぼ `new items: 0` を返し続けていた。

## 根本原因

`src/repository.ts` の `created_time: { this_week: {} }` フィルタは「ワークスペースのカレンダー週」に固定されるため、週境界をまたいだ瞬間に未投稿のブックマークがフィルタから永久に脱落していた。週の切れ目で投稿し損ねたアイテムが取り戻せない構造。

## 修正

1. **`this_week` → 8日 sliding window** (`fe8c3df`)
   - `buildFeedItemFilter(now: Date)` を pure 関数として切り出し、`created_time: { on_or_after: <now - 8日> }` に置換。週境界依存をなくし、ローリングで取りこぼしを救う。
   - in-source vitest を 2 件追加して filter shape と日付計算を固定。

2. **per-item try/catch で失敗を隔離** (`b6da656`)
   - `worker.ts` の for-loop 全体を try/catch していたため、1 件目の `saveFeedItemStatus` 失敗 (Notion 5xx 等) が後続アイテム全部を中止していた。8日窓拡張で重複投稿の表面積が広がることを踏まえ、アイテム単位で隔離。
   - 各アイテムの失敗は `console.error` + `sentry.captureException` で記録し、ループは継続。

3. **`fetchNewFeedItems` に `now` 注入を追加** (`b6da656`)
   - 第3引数 `now: Date = new Date()` を追加。将来のテストで wall clock を pin できる。

## レビュー

`/code-review ultra` ではなく `/code-review --fix` (xhigh effort: 9 angles × 8 candidates × 1-vote verify + sweep) を実行。43 → 25 + 6 → 1、合計 15 finding にランクダウン。CONFIRMED 4 / PLAUSIBLE 11 のうち、本 PR スコープ内で安全に適用できる 2 件 (per-item try/catch、clock injection) を反映。残り (8日窓そのものの仕様判断、network 共通定数化、circuit breaker 等) はスコープ外として別 issue 推奨。

## テスト

- `pnpm run test:ci` → 34/34 pass (新規 `buildFeedItemFilter` テスト 2 件含む)
- `pnpm run lint` → pass
